### PR TITLE
update to bdk v0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/weareseba/bdk-reserves"
 
 [dependencies]
-bdk = { version = "^0.18", default-features = false }
+bdk = { version = "0.19", default-features = false }
 bitcoinconsensus = "0.19.0-3"
 base64 = "^0.11"
 log = "^0.4"
@@ -18,4 +18,4 @@ log = "^0.4"
 [dev-dependencies]
 rstest = "^0.11"
 bdk-testutils = "^0.4"
-bdk = { version = "^0.18", default-features = true }
+bdk = { version = "0.19", default-features = true }

--- a/src/reserves.rs
+++ b/src/reserves.rs
@@ -20,7 +20,7 @@
 
 use bdk::bitcoin::blockdata::opcodes;
 use bdk::bitcoin::blockdata::script::{Builder, Script};
-use bdk::bitcoin::blockdata::transaction::{OutPoint, SigHashType, TxIn, TxOut};
+use bdk::bitcoin::blockdata::transaction::{EcdsaSighashType, OutPoint, TxIn, TxOut};
 use bdk::bitcoin::consensus::encode::serialize;
 use bdk::bitcoin::hash_types::{PubkeyHash, Txid};
 use bdk::bitcoin::hashes::{hash160, sha256d, Hash};
@@ -232,7 +232,7 @@ pub fn verify_proof(
 
     // Verify the SIGHASH
     if let Some((i, _psbt_in)) = psbt.inputs.iter().enumerate().find(|(_i, psbt_in)| {
-        psbt_in.sighash_type.is_some() && psbt_in.sighash_type != Some(SigHashType::All)
+        psbt_in.sighash_type.is_some() && psbt_in.sighash_type != Some(EcdsaSighashType::All.into())
     }) {
         return Err(ProofError::UnsupportedSighashType(i));
     }
@@ -446,7 +446,7 @@ mod test {
 
         let message = "This belongs to me.";
         let mut psbt = get_signed_proof();
-        psbt.global.unsigned_tx.input.truncate(1);
+        psbt.unsigned_tx.input.truncate(1);
         psbt.inputs.truncate(1);
 
         wallet.verify_proof(&psbt, message, None).unwrap();
@@ -460,7 +460,7 @@ mod test {
 
         let message = "This belongs to me.";
         let mut psbt = get_signed_proof();
-        psbt.global.unsigned_tx.output.clear();
+        psbt.unsigned_tx.output.clear();
         psbt.inputs.clear();
 
         wallet.verify_proof(&psbt, message, None).unwrap();
@@ -488,7 +488,7 @@ mod test {
 
         let message = "This belongs to me.";
         let mut psbt = get_signed_proof();
-        psbt.inputs[1].sighash_type = Some(SigHashType::SinglePlusAnyoneCanPay);
+        psbt.inputs[1].sighash_type = Some(EcdsaSighashType::SinglePlusAnyoneCanPay.into());
 
         wallet.verify_proof(&psbt, message, None).unwrap();
     }
@@ -508,7 +508,7 @@ mod test {
             network: Network::Testnet,
         }
         .script_pubkey();
-        psbt.global.unsigned_tx.output[0].script_pubkey = out_script_unspendable;
+        psbt.unsigned_tx.output[0].script_pubkey = out_script_unspendable;
 
         wallet.verify_proof(&psbt, message, None).unwrap();
     }
@@ -521,7 +521,7 @@ mod test {
 
         let message = "This belongs to me.";
         let mut psbt = get_signed_proof();
-        psbt.global.unsigned_tx.output[0].value = 123;
+        psbt.unsigned_tx.output[0].value = 123;
 
         wallet.verify_proof(&psbt, message, None).unwrap();
     }

--- a/tests/tampering.rs
+++ b/tests/tampering.rs
@@ -1,4 +1,4 @@
-use bdk::bitcoin::blockdata::transaction::SigHashType;
+use bdk::bitcoin::blockdata::transaction::EcdsaSighashType;
 use bdk::wallet::get_funded_wallet;
 use bdk::SignOptions;
 use bdk_reserves::reserves::*;
@@ -27,8 +27,7 @@ fn tampered_proof_message() {
     // change the message
     let message_bob = "This belongs to Bob.";
     let psbt_bob = wallet.create_proof(message_bob).unwrap();
-    psbt_alice.global.unsigned_tx.input[0].previous_output =
-        psbt_bob.global.unsigned_tx.input[0].previous_output;
+    psbt_alice.unsigned_tx.input[0].previous_output = psbt_bob.unsigned_tx.input[0].previous_output;
     psbt_alice.inputs[0].witness_utxo = psbt_bob.inputs[0].witness_utxo.clone();
 
     let res_alice = wallet.verify_proof(&psbt_alice, message_alice, None);
@@ -55,7 +54,7 @@ fn tampered_proof_sighash_tx() {
     };
 
     // set an unsupported sighash
-    psbt.inputs[1].sighash_type = Some(SigHashType::Single);
+    psbt.inputs[1].sighash_type = Some(EcdsaSighashType::Single.into());
 
     let _finalized = wallet.sign(&mut psbt, signopt).unwrap();
 
@@ -78,7 +77,7 @@ fn tampered_proof_miner_fee() {
     };
 
     // reduce the output value to grant a miner fee
-    psbt.global.unsigned_tx.output[0].value -= 100;
+    psbt.unsigned_tx.output[0].value -= 100;
 
     let _finalized = wallet.sign(&mut psbt, signopt).unwrap();
 


### PR DESCRIPTION
This is an update for migration to `bdk v0.19.0` and `rust-bitcoin v0.28`.

Latest update in bdk has changed few internals and I have updated the tests and the code for them.. 

We need this crate to be at `bdk v0.19.0` so we can move up the same in `bdk-cli`. 

Downstream PR dependent on this:  https://github.com/bitcoindevkit/bdk-cli/pull/92