### PR TITLE
Remove base64 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/weareseba/bdk-reserves"
 [dependencies]
 bdk = { version = "0.19", default-features = false }
 bitcoinconsensus = "0.19.0-3"
-base64 = "^0.11"
 log = "^0.4"
 
 [dev-dependencies]

--- a/src/reserves.rs
+++ b/src/reserves.rs
@@ -333,6 +333,7 @@ fn challenge_txin(message: &str) -> TxIn {
 #[cfg(test)]
 mod test {
     use super::*;
+    use bdk::bitcoin::base64;
     use bdk::bitcoin::consensus::encode::deserialize;
     use bdk::bitcoin::{Address, Network};
     use bdk::wallet::get_funded_wallet;


### PR DESCRIPTION
Currently the [base64](https://crates.io/crates/base64) and [base64-compat](https://crates.io/crates/base64-compat) are forks of each other and rust-bitcoin already exposes its preferred version of base64, and bdk reexports rust-bitcoin with `base64` feature flag. 

So `base64-compat` can directly be used and one more extra dependency can be removed. 