### PR TITLE
Upgrade bdk to 0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk-reserves"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Richard Ulrich <richard.ulrich@seba.swiss>"]
 edition = "2018"
 description = "Proof of reserves for bitcoin dev kit"
@@ -10,11 +10,11 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/weareseba/bdk-reserves"
 
 [dependencies]
-bdk = { version = "0.19", default-features = false }
+bdk = { version = "0.20", default-features = false }
 bitcoinconsensus = "0.19.0-3"
 log = "^0.4"
 
 [dev-dependencies]
 rstest = "^0.11"
 bdk-testutils = "^0.4"
-bdk = { version = "0.19", default-features = true }
+bdk = { version = "0.20", default-features = true }

--- a/src/reserves.rs
+++ b/src/reserves.rs
@@ -131,6 +131,7 @@ where
             .add_foreign_utxo(challenge_txin.previous_output, challenge_psbt_inp, 42)?
             .fee_absolute(0)
             .only_witness_utxo()
+            .current_height(0)
             .drain_to(out_script_unspendable)
             .ordering(TxOrdering::Untouched);
         let (psbt, _details) = builder.finish().unwrap();

--- a/tests/multi_sig.rs
+++ b/tests/multi_sig.rs
@@ -128,6 +128,7 @@ fn test_proof_multisig(
 
     let signopts = SignOptions {
         trust_witness_utxo: true,
+        remove_partial_sigs: false,
         ..Default::default()
     };
     let finalized = wallet1.sign(&mut psbt, signopts.clone())?;

--- a/tests/single_sig.rs
+++ b/tests/single_sig.rs
@@ -24,6 +24,7 @@ fn test_proof(#[case] descriptor: &'static str) -> Result<(), ProofError> {
         &mut psbt,
         SignOptions {
             trust_witness_utxo: true,
+            remove_partial_sigs: false,
             ..Default::default()
         },
     )?;


### PR DESCRIPTION
The only notable change in this release is that by default bdk tries to prevent fee-sniping attacks by setting the nlocktime to the current height, so it's now necessary to set it at zero explicitly to get deterministic proof of reserves.

On top of this, the new default behavior is to remove partial signatures after finalizing a tx, which should shrink down the size of proofs quite a bit as you can see in the test updated here: https://github.com/bitcoindevkit/bdk-cli/pull/108

This is a draft for now while we wait for the release, there's a one-week window to report bugs so if you notice anything wrong here let us know.